### PR TITLE
fix(branding) Fix duplicate query to branding

### DIFF
--- a/src/lib/intercom/branding.js
+++ b/src/lib/intercom/branding.js
@@ -8,18 +8,17 @@ const canHandle = event =>
   event?.data?.event === 'request.cssVars' && event?.data?.namespace === 'etvas'
 
 const handle = async event => {
+  const { origin } = event
+  const iframeId = getIframeIdByOrigin(origin, false)
+  const iframe = dom.getElement(iframeId)
+  if (!iframe) {
+    return
+  }
   let branding = config.get('branding')
   if (!branding) {
     branding = await fetchBranding()
   }
 
-  const { origin } = event
-  const iframeId = getIframeIdByOrigin(origin, false)
-  const iframe = dom.getElement(iframeId)
-  if (!iframe) {
-    console.error('Could not find iframe ', iframeId)
-    return
-  }
   iframe.contentWindow.postMessage(
     {
       namespace: 'etvas',


### PR DESCRIPTION
When showing productCard, the iframe will request branding (responded by the enclosing Customer Portal mechanism) but the Automat catches the message and tries to respond by querying the branding endpoint. The result goes nowhere, because the iframe origin does not match a bundled product use.

The fix is to first check if the iframe that should request the branding is actually in DOM.